### PR TITLE
Ci lockfile mismatch

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 5.9.3
 
   packages/core:
-    devDependencies:
+    dependencies:
       '@napi-rs/cli':
         specifier: ^3.0.0-alpha.69
         version: 3.5.1(@emnapi/runtime@1.8.1)(@types/node@22.19.7)


### PR DESCRIPTION
## Summary

Fixes a CI failure caused by an outdated `pnpm-lock.yaml` where `@napi-rs/cli` was incorrectly listed as a `devDependencies` entry for `packages/core` instead of a `dependencies` entry.

## Changes

- Updated `pnpm-lock.yaml` to correctly categorize `@napi-rs/cli` as a `dependency` for `packages/core`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing

Describe how you tested your changes:

- [x] Unit tests pass (`just test-rust`)
- [x] Linting passes (`just lint`)
- [x] Manual testing performed (The `pnpm-lock.yaml` was updated by running `pnpm install`. The fix will be validated by the CI passing.)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Related Issues

Closes #

---
<a href="https://cursor.com/background-agent?bcId=bc-f06748fd-65ed-4e7b-9b07-f116701c590e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f06748fd-65ed-4e7b-9b07-f116701c590e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

