### PR TITLE
Add password generation tips to user add and passwd commands

### DIFF
--- a/packages/cli-rust/src/commands/user/add.rs
+++ b/packages/cli-rust/src/commands/user/add.rs
@@ -14,6 +14,9 @@ use opencode_cloud_core::{load_config_or_default, save_config};
 
 /// Arguments for the user add command
 #[derive(Args)]
+#[command(
+    after_help = "Tip: Use --generate (-g) to auto-generate a secure password instead of typing one."
+)]
 pub struct UserAddArgs {
     /// Username to create (default: opencode if not provided)
     pub username: Option<String>,
@@ -96,6 +99,11 @@ pub async fn cmd_user_add(
                     "Authentication is handled by the system via PAM - we don't store passwords."
                 )
                 .dim()
+            );
+            println!(
+                "  {} Use {} to auto-generate a secure password.",
+                style("Tip:").cyan(),
+                style("--generate (-g)").bold()
             );
         }
         let pwd = Password::new()

--- a/packages/cli-rust/src/commands/user/passwd.rs
+++ b/packages/cli-rust/src/commands/user/passwd.rs
@@ -13,6 +13,9 @@ use opencode_cloud_core::docker::{
 
 /// Arguments for the user passwd command
 #[derive(Args)]
+#[command(
+    after_help = "Tip: Use --generate (-g) to auto-generate a secure password instead of typing one."
+)]
 pub struct UserPasswdArgs {
     /// Username to change password for
     pub username: String,
@@ -48,6 +51,13 @@ pub async fn cmd_user_passwd(
     let password = if args.generate {
         generate_random_password()
     } else {
+        if !quiet {
+            println!(
+                "  {} Use {} to auto-generate a secure password.",
+                style("Tip:").cyan(),
+                style("--generate (-g)").bold()
+            );
+        }
         Password::new()
             .with_prompt("New password")
             .with_confirmation("Confirm new password", "Passwords do not match")


### PR DESCRIPTION
## Summary

Adds helpful tips to guide users toward using the `--generate (-g)` flag for secure password generation in the `user add` and `user passwd` commands. This improves the user experience by making the password generation feature more discoverable.

## Changes

- Add `after_help` text to `UserAddArgs` command struct displaying the password generation tip
- Add inline tip message in `cmd_user_add` when prompting for password interactively
- Add `after_help` text to `UserPasswdArgs` command struct displaying the password generation tip
- Add inline tip message in `cmd_user_passwd` when prompting for password interactively (respects quiet mode)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Testing

Describe how you tested your changes:

- [ ] Unit tests pass (`just test-rust`)
- [ ] Linting passes (`just lint`)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Related Issues

N/A

https://claude.ai/code/session_012WWjav9gTbLFAN4gKA9kDB