### PR TITLE
Fix stdin handling and update reqwest TLS configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ tokio-retry = "0.3"
 indicatif = { version = "0.17", features = ["tokio", "futures"] }
 http-body-util = "0.1"
 bytes = "1.9"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-webpki-roots", "json"] }
 
 # CLI utilities
 webbrowser = "1.0"

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -47,7 +47,7 @@ tokio-retry = "0.3"
 indicatif = { version = "0.17", features = ["tokio", "futures"] }
 http-body-util = "0.1"
 bytes = "1.9"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-webpki-roots", "json"] }
 
 # Platform service management (macOS)
 plist = "1.8"


### PR DESCRIPTION
## Summary

This PR addresses two issues: fixes a potential hang in the service stop command when stdin reading persists after the stop completes, and updates the reqwest TLS configuration to use webpki roots for better compatibility.

## Changes

- **Stdin handling fix**: Refactored `stop_service_with_spinner` to spawn stdin reading as a separate task that can be aborted. This prevents the program from hanging when the service stop completes before the user presses Enter, as tokio's async stdin spawns an internal blocking thread that persists even after the future is dropped.
- **TLS configuration**: Updated reqwest dependency in both `Cargo.toml` and `packages/core/Cargo.toml` to use `rustls-tls-webpki-roots` instead of `rustls-tls` for improved certificate validation and compatibility.
- **Improved comments**: Added detailed comments explaining the stdin spawning behavior and the different exit paths in the select! macro.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactoring (no functional changes)

## Testing

- [ ] Unit tests pass (`just test-rust`)
- [ ] Linting passes (`just lint`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Related Issues

N/A

https://claude.ai/code/session_01J4qzzsM3QEPXdtzQcuACwa