### PR TITLE
Upgrade reqwest from 0.12 to 0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1586,7 +1586,7 @@ dependencies = [
  "gix-quote",
  "gix-sec",
  "gix-url",
- "reqwest 0.13.1",
+ "reqwest",
  "thiserror 2.0.18",
 ]
 
@@ -1859,7 +1859,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.5",
 ]
 
 [[package]]
@@ -2585,7 +2584,7 @@ dependencies = [
  "indicatif",
  "opencode-cloud-core",
  "rand 0.9.2",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "sysinfo",
@@ -2617,7 +2616,7 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "plist",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "ssh2-config-rs",
@@ -3055,44 +3054,6 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower 0.5.3",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots 1.0.5",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
@@ -3119,6 +3080,8 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
+ "serde",
+ "serde_json",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -3129,6 +3092,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 1.0.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ tokio-retry = "0.3"
 indicatif = { version = "0.17", features = ["tokio", "futures"] }
 http-body-util = "0.1"
 bytes = "1.9"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-webpki-roots", "json"] }
+reqwest = { version = "0.13", default-features = false, features = ["rustls", "webpki-roots", "json"] }
 
 # CLI utilities
 webbrowser = "1.0"

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -47,7 +47,7 @@ tokio-retry = "0.3"
 indicatif = { version = "0.17", features = ["tokio", "futures"] }
 http-body-util = "0.1"
 bytes = "1.9"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-webpki-roots", "json"] }
+reqwest = { version = "0.13", default-features = false, features = ["rustls", "webpki-roots", "json"] }
 
 # Platform service management (macOS)
 plist = "1.8"


### PR DESCRIPTION
## Summary

Upgrade the `reqwest` HTTP client library from version 0.12 to 0.13 across the project. This update simplifies dependency management by consolidating multiple reqwest versions into a single version and updates the TLS feature configuration.

## Changes

- Upgrade `reqwest` dependency from 0.12.28 to 0.13.1 in root `Cargo.toml` and `packages/core/Cargo.toml`
- Update reqwest feature flags from `["rustls-tls-webpki-roots", "json"]` to `["rustls", "webpki-roots", "json"]` to match 0.13 API
- Remove duplicate reqwest 0.12.28 entry from `Cargo.lock`
- Update `Cargo.lock` to reflect the new reqwest 0.13.1 as the single version across all packages
- Add `serde` and `serde_json` to reqwest 0.13.1 dependencies in `Cargo.lock`
- Move `webpki-roots` dependency from hyper-rustls to reqwest in `Cargo.lock`

## Type of Change

- [x] Refactoring (no functional changes)
- [x] Dependency upgrade

## Testing

- [ ] Unit tests pass (`just test-rust`)
- [ ] Linting passes (`just lint`)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Notes

This upgrade consolidates the project to use a single version of reqwest (0.13.1) instead of having both 0.12.28 and 0.13.1 as dependencies, reducing dependency bloat and potential version conflicts.

https://claude.ai/code/session_01SRn7RiPmHuxdyPNgbvAF93