### PR TITLE
Upgrade whoami to 2.1 and handle username retrieval errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,7 +880,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -2329,7 +2329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -3949,6 +3949,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3959,9 +3968,12 @@ dependencies = [
 
 [[package]]
 name = "wasite"
-version = "0.1.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -4078,9 +4090,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.6.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+checksum = "8fae98cf96deed1b7572272dfc777713c249ae40aa1cf8862e091e8b745f5361"
 dependencies = [
  "libredox",
  "wasite",

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -53,7 +53,7 @@ reqwest = { version = "0.13", default-features = false, features = ["rustls", "w
 plist = "1.8"
 
 # Host management
-whoami = "1.5"
+whoami = "2.1"
 ssh2-config-rs = "0.7.2"
 dirs = "6"
 

--- a/packages/core/src/host/schema.rs
+++ b/packages/core/src/host/schema.rs
@@ -38,7 +38,7 @@ pub struct HostConfig {
 }
 
 fn default_user() -> String {
-    whoami::username()
+    whoami::username().unwrap_or_else(|_| "user".to_string())
 }
 
 impl Default for HostConfig {


### PR DESCRIPTION
## Summary

Upgrade the `whoami` crate from version 1.5 to 2.1, which introduces a breaking API change where `whoami::username()` now returns a `Result` instead of a `String`. This PR updates the dependency and handles the potential error case gracefully.

## Changes

- Upgrade `whoami` dependency from 1.5 to 2.1 in `packages/core/Cargo.toml`
- Update `Cargo.lock` to reflect new `whoami` 2.1.0 and its transitive dependencies:
  - `wasite` upgraded from 0.1.0 to 1.0.2
  - `wasi` pinned to 0.11.1+wasi-snapshot-preview1 in existing dependencies
  - New `wasi` 0.14.7+wasi-0.2.4 added as a dependency of `wasite`
- Update `default_user()` function in `packages/core/src/host/schema.rs` to handle the `Result` return type by providing a fallback value of `"user"` when username retrieval fails

## Type of Change

- [x] Dependency upgrade (non-breaking change that updates external crate)
- [x] Bug fix (handles potential errors in username retrieval)

## Testing

Describe how you tested your changes:

- [ ] Unit tests pass (`just test-rust`)
- [ ] Linting passes (`just lint`)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Related Issues

N/A

https://claude.ai/code/session_01FjPuTe8aJr25G84ScsaTvn